### PR TITLE
Convert Open Text Input to extend QuestionView

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "homepage": "https://github.com/learningpool/adapt-contrib-openTextInput",
   "authors": [
     "Thomas Eitler <thomas.eitler@learnchamp.com>",

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -66,6 +66,9 @@ define(function(require) {
           }
           return answer && answer.trim() !== '';
         },
+        isCorrect: function() {
+          return this.canSubmit();
+        },
 
          unsavedChangesNotification: function(eventToTrigger) {
             var promptObject = {
@@ -98,6 +101,7 @@ define(function(require) {
         onQuestionRendered: function() {
             //set component to ready
             this.$textbox = this.$('.openTextInput-item-textbox');
+            this.listenTo(this.buttonsView, 'buttons:submit', this.onActionClicked);
             this.countCharacter();
             this.setReadyStatus();
 
@@ -235,10 +239,13 @@ define(function(require) {
 
         onActionClicked: function(event) {
             if (this.model.get('_isComplete')) {
-                if (this.model.get('_buttonState') == 'model') {
-                    this.showUserAnswer();
+                // Keep it enabled so we can show the model answer,
+                // which in this function we are making sure is available.
+                this.buttonsView.$('.buttons-action').a11y_cntrl_enabled(true);
+                if (this.model.get('_buttonState') == 'correct') {
+                  this.model.set('_buttonState', 'showCorrectAnswer');
                 } else {
-                    this.showModelAnswer();
+                  this.model.set('_buttonState', 'hideCorrectAnswer');
                 }
             } else {
                 this.submitAnswer();
@@ -284,6 +291,7 @@ define(function(require) {
         },
 
         showCorrectAnswer: function() {
+            this.buttonsView.$('.buttons-action').a11y_cntrl_enabled(true);
             this.model.set('_buttonState', 'hideCorrectAnswer');
             this.updateActionButton(this.model.get('_buttons').showUserAnswer);
             var modelAnswer = this.model.get('modelAnswer');
@@ -294,6 +302,7 @@ define(function(require) {
         },
 
         hideCorrectAnswer: function() {
+            this.buttonsView.$('.buttons-action').a11y_cntrl_enabled(true);
             this.model.set('_buttonState', 'showCorrectAnswer');
             this.updateActionButton(this.model.get('_buttons').showModelAnswer);
             this.$textbox.val(this.model.get('_userAnswer')).show();

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -9,10 +9,10 @@
 
 define(function(require) {
 
-    var ComponentView = require('coreViews/componentView');
+    var QuestionView = require('coreViews/questionView');
     var Adapt = require('coreJS/adapt');
 
-    var OpenTextInput = ComponentView.extend({
+    var OpenTextInput = QuestionView.extend({
 
         events: {
             'click .openTextInput-save-button'  : 'onSaveClicked',
@@ -21,7 +21,7 @@ define(function(require) {
             'keyup .openTextInput-item-textbox' : 'onKeyUpTextarea'
         },
 
-        preRender: function() {
+        setupQuestion: function() {
             this.listenTo(this.model, 'change:_isSaved', this.onSaveChanged);
             this.listenTo(this.model, 'change:_userAnswer', this.onUserAnswerChanged);
             this.listenToOnce(Adapt, 'navigation:backButton', this.handleBackNavigation);
@@ -29,7 +29,7 @@ define(function(require) {
 
             // Intercept the routing so that text entered can be saved.
             Adapt.router.set('_canNavigate', false, {pluginName:'_openTextInput'});
-            
+
             if (!this.model.get('_userAnswer')) {
                 var userAnswer = this.getUserAnswer();
                 if (userAnswer) {
@@ -48,7 +48,7 @@ define(function(require) {
 
         checkForChanges: function(eventToTrigger) {
             var userAnswer = this.model.get("_userAnswer") || '';
-            
+
             if (userAnswer === this.$textbox.val()) {
                 Adapt.router.set('_canNavigate', true, {pluginName:'_openTextInput'});
                 Adapt.trigger(eventToTrigger);
@@ -58,6 +58,14 @@ define(function(require) {
                 this.unsavedChangesNotification(eventToTrigger);
             }
          },
+        canSubmit: function() {
+          var answer = this.model.get('_userAnswer');
+          if (answer && answer.trim() !== '') {
+            // it's correct if there's any text entered.
+            this.model.set('_isCorrect', true);
+          }
+          return answer && answer.trim() !== '';
+        },
 
          unsavedChangesNotification: function(eventToTrigger) {
             var promptObject = {
@@ -87,7 +95,7 @@ define(function(require) {
             Adapt.trigger('notify:prompt', promptObject);
         },
 
-        postRender: function() {
+        onQuestionRendered: function() {
             //set component to ready
             this.$textbox = this.$('.openTextInput-item-textbox');
             this.countCharacter();

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -283,18 +283,21 @@ define(function(require) {
                 .html(buttonText);
         },
 
-        showModelAnswer: function() {
-            this.model.set('_buttonState', 'model');
+        showCorrectAnswer: function() {
+            this.model.set('_buttonState', 'hideCorrectAnswer');
             this.updateActionButton(this.model.get('_buttons').showUserAnswer);
             var modelAnswer = this.model.get('modelAnswer');
             modelAnswer = modelAnswer.replace(/\\n|&#10;/g, "\n");
-            this.$textbox.val(modelAnswer);
+            modelAnswer = '<div class="openTextInput-item-modelanswer openTextInput-item-textbox">' + modelAnswer + '</div>';
+            this.$textbox.hide();
+            this.$textbox.after(modelAnswer);
         },
 
-        showUserAnswer: function() {
-            this.model.set('_buttonState', 'user');
+        hideCorrectAnswer: function() {
+            this.model.set('_buttonState', 'showCorrectAnswer');
             this.updateActionButton(this.model.get('_buttons').showModelAnswer);
-            this.$textbox.val(this.model.get('_userAnswer'));
+            this.$textbox.val(this.model.get('_userAnswer')).show();
+            this.$('.openTextInput-item-modelanswer').remove();
         }
     });
 

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -17,7 +17,6 @@ define(function(require) {
         events: {
             'click .openTextInput-save-button'  : 'onSaveClicked',
             'click .openTextInput-clear-button' : 'onClearClicked',
-            'click .openTextInput-action-button': 'onActionClicked',
             'keyup .openTextInput-item-textbox' : 'onKeyUpTextarea'
         },
 
@@ -108,12 +107,6 @@ define(function(require) {
             if (this.model.get('_isComplete')) {
                 this.disableButtons();
                 this.disableTextarea();
-                if (!this.model.get('modelAnswer')) {
-                    this.$('.openTextInput-action-button')
-                        .prop('disabled', true)
-                } else {
-                    this.showUserAnswer();
-                }
             }
         },
 
@@ -247,8 +240,6 @@ define(function(require) {
                 } else {
                   this.model.set('_buttonState', 'hideCorrectAnswer');
                 }
-            } else {
-                this.submitAnswer();
             }
         },
 
@@ -256,12 +247,6 @@ define(function(require) {
             this.storeUserAnswer();
             this.disableButtons();
             this.disableTextarea();
-            if (!this.model.get('modelAnswer')) {
-                this.$('.openTextInput-action-button')
-                    .prop('disabled', true);
-            } else {
-                this.showUserAnswer();
-            }
 
             this.setCompletionStatus();
 
@@ -291,7 +276,7 @@ define(function(require) {
         },
 
         showCorrectAnswer: function() {
-            this.buttonsView.$('.buttons-action').a11y_cntrl_enabled(true);
+            this.$('.buttons-action').a11y_cntrl_enabled(true);
             this.model.set('_buttonState', 'hideCorrectAnswer');
             this.updateActionButton(this.model.get('_buttons').showUserAnswer);
             var modelAnswer = this.model.get('modelAnswer');
@@ -302,9 +287,12 @@ define(function(require) {
         },
 
         hideCorrectAnswer: function() {
-            this.buttonsView.$('.buttons-action').a11y_cntrl_enabled(true);
+            this.$('.buttons-action').a11y_cntrl_enabled(true);
             this.model.set('_buttonState', 'showCorrectAnswer');
             this.updateActionButton(this.model.get('_buttons').showModelAnswer);
+            if (this.$textbox === undefined) {
+              this.$textbox = this.$('.openTextInput-item-textbox');
+            }
             this.$textbox.val(this.model.get('_userAnswer')).show();
             this.$('.openTextInput-item-modelanswer').remove();
         }

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -58,11 +58,7 @@ define(function(require) {
             }
          },
         canSubmit: function() {
-          var answer = this.model.get('_userAnswer');
-          if (answer && answer.trim() !== '') {
-            // it's correct if there's any text entered.
-            this.model.set('_isCorrect', true);
-          }
+          var answer = this.$textbox.val();
           return answer && answer.trim() !== '';
         },
         isCorrect: function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "0.0.9",
+  "version": "1.0.0",
   "description": "A question component that allows the learner to input open text based upon a question stem",
   "main": "",
   "scripts": {

--- a/properties.schema
+++ b/properties.schema
@@ -49,6 +49,33 @@
       "validators": ["required", "number"],
       "help": "The number textarea rows"
     },
+    "_recordInteraction": {
+      "type":"boolean",
+      "required":false,
+      "default": true,
+      "title": "Record interaction",
+      "inputType": {"type": "Boolean", "options": [true, false]},
+      "validators": [],
+      "help": "If set to 'true', the user's answer(s) will be recorded to cmi.interactions on the LMS (where supported)."
+    },
+    "_attempts": {
+      "type":"number",
+      "required":true,
+      "default":1,
+      "title": "Attempts",
+      "inputType":"Number",
+      "validators": ["required", "number"],
+      "help": "How many attempts the learner is allowed"
+    },
+    "_shouldDisplayAttempts": {
+      "type":"boolean",
+      "required":false,
+      "default": false,
+      "title": "Display Attempts",
+      "inputType": {"type": "Boolean", "options": [true, false]},
+      "validators": [],
+      "help": "Select 'true' to display the numbers of attempts left"
+    },
     "clearNotificationTitle": {
       "type":"string",
       "required":true,
@@ -125,39 +152,127 @@
           "validators": [],
           "help": "Button label text for the save button"
         },
-        "submit": {
-          "type":"string",
-          "required": false,
-          "default": "",
-          "inputType": "QuestionButton",
-          "validators": [],
-          "help": "Button label text for the submit button"
+        "_submit":{
+          "type":"object",
+          "title": "Submit",
+          "properties":{
+            "buttonText": {
+              "type":"string",
+              "required": false,
+              "default": "Submit",
+              "title": "",
+              "inputType": "QuestionButton",
+              "validators": [],
+              "help": "Button label text for the submit button"
+            },
+            "ariaLabel": {
+              "type":"string",
+              "required": false,
+              "default": "Submit",
+              "title": "",
+              "inputType": "Text",
+              "validators": [],
+              "help": "Aria label for the submit button"
+            }
+          }
         },
-        "showModelAnswer": {
-          "type":"string",
-          "required": false,
-          "default": "",
-          "inputType": "QuestionButton",
-          "validators": [],
-          "help": "Button label text to show the model answer"
+        "_showCorrectAnswer": {
+          "type":"object",
+          "title": "Show Correct Answer",
+          "properties":{
+            "buttonText": {
+              "type":"string",
+              "required": false,
+              "default": "Show model answer",
+              "title": "",
+              "inputType": "QuestionButton",
+              "validators": [],
+              "help": "Button label text to show the model answer"
+            },
+            "ariaLabel": {
+              "type":"string",
+              "required": false,
+              "default": "Show model answer",
+              "title": "",
+              "inputType": "Text",
+              "validators": [],
+              "help": "Aria label for the show model answer button"
+            }
+          }
         },
-        "showUserAnswer": {
-          "type":"string",
-          "required": false,
-          "default": "",
-          "inputType": "QuestionButton",
-          "validators": [],
-          "help": "Button label text to show the user's answer"
+        "_hideCorrectAnswer": {
+          "type":"object",
+          "title": "Hide Correct Answer",
+          "properties":{
+            "buttonText": {
+              "type":"string",
+              "required": false,
+              "default": "Hide model answer",
+              "title": "",
+              "inputType": "QuestionButton",
+              "validators": [],
+              "help": "Button label text to hide the model answer"
+            },
+            "ariaLabel": {
+              "type":"string",
+              "required": false,
+              "default": "Hide model answer",
+              "title": "",
+              "inputType": "Text",
+              "validators": [],
+              "help": "Aria label for the hide model answer button"
+            }
+          }
         },
-        "clear": {
-          "type":"string",
-          "required": false,
-          "default": "",
-          "inputType": "QuestionButton",
-          "validators": [],
-          "help": "Button label text for the clear button"
-        } 
-      }      
+        "_showFeedback": {
+          "type":"object",
+          "title": "Show Feedback",
+          "properties": {
+            "buttonText": {
+              "type": "string",
+              "required": false,
+              "default": "",
+              "title": "",
+              "inputType": "QuestionButton",
+              "validators": [],
+              "help": "Button label text to show feedback"
+            },
+            "ariaLabel": {
+              "type": "string",
+              "required": false,
+              "default": "",
+              "title": "",
+              "inputType": "Text",
+              "validators": [],
+              "help": "Aria label for the show feedback button"
+            }
+          }
+        },
+        "_reset": {
+          "type":"object",
+          "title": "Reset",
+          "properties":{
+            "buttonText": {
+              "type":"string",
+              "required": false,
+              "default": "Reset",
+              "title": "",
+              "inputType": "QuestionButton",
+              "validators": [],
+              "help": "Button label text for the reset button"
+            },
+            "ariaLabel": {
+              "type":"string",
+              "required": false,
+              "default": "Reset",
+              "title": "",
+              "inputType": "Text",
+              "validators": [],
+              "help": "Aria label for the reset button"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -58,24 +58,6 @@
       "validators": [],
       "help": "If set to 'true', the user's answer(s) will be recorded to cmi.interactions on the LMS (where supported)."
     },
-    "_attempts": {
-      "type":"number",
-      "required":true,
-      "default":1,
-      "title": "Attempts",
-      "inputType":"Number",
-      "validators": ["required", "number"],
-      "help": "How many attempts the learner is allowed"
-    },
-    "_shouldDisplayAttempts": {
-      "type":"boolean",
-      "required":false,
-      "default": false,
-      "title": "Display Attempts",
-      "inputType": {"type": "Boolean", "options": [true, false]},
-      "validators": [],
-      "help": "Select 'true' to display the numbers of attempts left"
-    },
     "clearNotificationTitle": {
       "type":"string",
       "required":true,

--- a/properties.schema
+++ b/properties.schema
@@ -117,7 +117,7 @@
       "required":true,
       "default": "",
       "title": "Model answer",
-      "inputType": "Text",
+      "inputType": "TextArea",
       "validators": ["required"],
       "help": "This is the model answer which will be displayed when the model answer button is clicked"
     },

--- a/templates/openTextInput.hbs
+++ b/templates/openTextInput.hbs
@@ -16,19 +16,10 @@
 
     <div class="openTextInput-answer-container">
         <textarea class="openTextInput-item-textbox"
-            rows={{_numberOfRows}} placeholder="{{placeholder}}" 
+            rows={{_numberOfRows}} placeholder="{{placeholder}}"
             maxlength="{{_allowedCharacters}}">{{_userAnswer}}</textarea>
     </div>
         <div class="buttons">
-            <button class="openTextInput-save-button" disabled="true">
-                {{_buttons.save}}
-            </button>    
-            <button class="openTextInput-clear-button" {{#unless _userAnswer}}disabled="true"{{/unless}}>
-                {{_buttons.clear}}
-            </button>  
-            <button class="openTextInput-action-button" {{#unless _userAnswer}}disabled="true"{{/unless}}>
-                {{_buttons.submit}}
-            </button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
There's still a fair amount of unnecessary code in the adapt-contrib-openTextInput.js file, but this I think is sufficient to make it properly extend question view.

The code to auto-save without prompting (or make the prompts work properly) will be done as a separate PR.

I'm not sure how this would work with existing courses as the schema has changed. I'd appreciate direction there...