### PR TITLE
removing code that applies a margin to top of model answer text

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "homepage": "https://github.com/learningpool/adapt-contrib-openTextInput",
   "authors": [
     "Thomas Eitler <thomas.eitler@learnchamp.com>",

--- a/less/opentextinput.less
+++ b/less/opentextinput.less
@@ -79,5 +79,20 @@
                 width: 100%;
             }
         }
+
     }
+    .openTextInput-inner {
+        .openTextInput-widget {
+            .openTextInput-item-textbox {
+                &.openTextInput-item-modelanswer {
+                background-color: #fff;
+                max-height: none;
+                    p {
+                        margin: 16px;
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A question component that allows the learner to input open text based upon a question stem",
   "main": "",
   "scripts": {


### PR DESCRIPTION
Removed a line of code (line 89) which applies a margin to the top of the model answer text. Works fine in Financial Services theme (which now has it as part of the theme LESS), but causes issues on other themes.

Version bump is from 1.0.1 to 1.0.2, not as shown below.