### PR TITLE
Adapt-1464 - IE8 and iPad- Submit button is not active

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/learningpool/adapt-contrib-openTextInput",
   "authors": [
     "Thomas Eitler <thomas.eitler@learnchamp.com>",

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -37,6 +37,13 @@ define(function(require) {
 
     canSubmit: function() {
       var answer = this.$textbox.val();
+
+      if (typeof String.prototype.trim !== 'function') {
+        String.prototype.trim = function() {
+          return this.replace(/^\s+|\s+$/g, '');
+        }
+      }
+
       return answer && answer.trim() !== '';
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A question component that allows the learner to input open text based upon a question stem",
   "main": "",
   "scripts": {


### PR DESCRIPTION
IE8 does not support .trim() function which was causing issues viewing courses with an open text input component. Implemented a fix for this.