### PR TITLE
Fix persistance issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "framework": "^2.0.17",
   "homepage": "https://github.com/learningpool/adapt-contrib-openTextInput",
   "authors": [

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -33,7 +33,6 @@ define([
       // Open Text Input cannot show feedback.
       this.model.set('_canShowFeedback', false);
 
-
       this.formatPlaceholder();
 
       if (!this.model.get('_userAnswer')) {
@@ -285,5 +284,29 @@ define([
   });
 
   Adapt.register('openTextInput', OpenTextInput);
+  
+  Adapt.once('adapt:start', restoreQuestionStatusPolyfill);
+
+    /**
+     * Spoor cannot store text input values and so the completion status of this component does not get
+     * saved or restored properly. This function ensures that the question's completion status is
+     * restored in a way that other extensions e.g. learning objectives can obtain accurate data for processing
+     *
+     */
+  function restoreQuestionStatusPolyfill() {
+    Adapt.components.each(function(component) {
+      if (component.get('_component') !== 'openTextInput') {
+        return;
+      }
+
+      // If the component is complete then it must be correct
+      if (component.get('_isComplete')) {
+        component.set('_isCorrect', true);
+
+        // Add a manual trigger just in case any extensions listening for this change have already loaded
+        component.trigger('change:_isComplete', component, true);
+      }
+    });
+  }
 
 });

--- a/js/adapt-contrib-openTextInput.js
+++ b/js/adapt-contrib-openTextInput.js
@@ -93,7 +93,7 @@ define([
     },
 
     canSubmit: function() {
-      var answer = this.$textbox.val();
+      var answer = this.model.get('_userAnswer');
 
       if (typeof String.prototype.trim !== 'function') {
         String.prototype.trim = function() {
@@ -300,8 +300,12 @@ define([
       }
 
       // If the component is complete then it must be correct
+        // _isInteractionComplete needs to be set to true so marking is restored correctly
       if (component.get('_isComplete')) {
-        component.set('_isCorrect', true);
+          component.set({
+              _isCorrect: true,
+              _isInteractionComplete: true
+          });
 
         // Add a manual trigger just in case any extensions listening for this change have already loaded
         component.trigger('change:_isComplete', component, true);


### PR DESCRIPTION
This component's status does not get stored/restored correctly as Spoor cannot store string values. You will see a console message to this effect when submitting the question.

This unfortunately means that any extension that relies on reading values like `_isCorrect` will not get accurate data.

This fix is a dirty workaround that works by checking whether any open text components are complete. If they are then setting `_isCorrect` and `_isInteractionComplete` manually will ensure that marking is restored and any extensions using these values get correct data.