### PR TITLE
ADAPT-6070

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-openTextInput",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "framework": ">=2.0.17",
   "homepage": "https://github.com/learningpool/adapt-contrib-openTextInput",
   "authors": [

--- a/less/opentextinput.less
+++ b/less/opentextinput.less
@@ -103,7 +103,7 @@
                 &.openTextInput-item-modelanswer {
                     background-color: #fff;
                     max-height: none;
-                        p {
+                        p, ul {
                             margin: 16px;
                         }
                 }    

--- a/less/opentextinput.less
+++ b/less/opentextinput.less
@@ -103,7 +103,7 @@
                 &.openTextInput-item-modelanswer {
                     background-color: #fff;
                     max-height: none;
-                        p, ul {
+                        p, ul, ol {
                             margin: 16px;
                         }
                 }    


### PR DESCRIPTION
ul lists now also targeted with margin changes

margin was being set on <p> tags only, leaving <ul> tags to the left of the text box